### PR TITLE
Integrate AIP72 Token Minter standard

### DIFF
--- a/studio/Move.toml
+++ b/studio/Move.toml
@@ -2,16 +2,15 @@
 name = 'studio'
 version = '0.0.2'
 
-[dependencies.AptosFramework]
-git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
-subdir = 'aptos-move/framework/aptos-framework'
-
-[dependencies.AptosTokenObjects]
-git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
-subdir = 'aptos-move/framework/aptos-token-objects'
+[dependencies.TokenMinter]
+git = 'https://github.com/aptos-labs/token-minter.git'
+rev = 'b340fe9bc71449c3f9bb24f17c918c3b84b681ab'
+subdir = 'token-minter/'
 
 [addresses]
 townespace = '0x07ff0308d16a5041ace8e7e306a60b2946b6a4aee0e7e923b8f20e49bf3508ce'
 admin = '0x07ff0308d16a5041ace8e7e306a60b2946b6a4aee0e7e923b8f20e49bf3508ce'
+minter = '_'
+
+[dev-addresses]
+minter = "0x123"

--- a/studio/sources/studio.move
+++ b/studio/sources/studio.move
@@ -143,10 +143,7 @@ module townespace::studio {
         // TODO: assert input sanitazation 
         core::equip_trait_internal(owner_signer, composable_object, trait_object);
         // Update uri
-        update_uri(
-            object::object_address(&composable_object),
-            new_uri
-            );
+        update_uri(owner_signer, composable_object, new_uri);
     }
 
     // Decompose one object
@@ -160,10 +157,7 @@ module townespace::studio {
         // TODO: assert owner
         core::unequip_trait_internal(owner_signer, composable_object, trait_object);
         // Update uri
-        update_uri(
-            object::object_address(&composable_object), 
-            new_uri
-            );
+        update_uri(owner_signer, composable_object, new_uri);
     }
 
     // Decompose an entire composable token
@@ -209,14 +203,16 @@ module townespace::studio {
     // --------
     // Composable Token
     inline fun update_uri(
-        composable_object_address: address,
+        owner_signer: &signer,
+        composable_object: Object<Composable>,
         new_uri: String
     ) {
         // TODO: asserts 
         core::update_uri_internal(
-            composable_object_address, 
+            owner_signer,
+            composable_object,
             new_uri
-            );
+        );
         // TODO: events
     }
 


### PR DESCRIPTION
##  Description
With the new AIP72 Token Minter standard, aim is to use this standard to enable ease of digital asset development, whilst adopting best practices within the Aptos ecosystem.

### Changes
- Creating Collection and Token refs via token minter.
- Using token minter provided functions to update token metadata, such as uri etc.

#### Token Minter Repo: https://github.com/aptos-labs/token-minter